### PR TITLE
Added selective line parameter "incomingLines"

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A device is configured by specifying the following:
 | port | The port where the Fritz device reports call statistic data. This default is 1012. |
 | incomingName | The name of the contact sensor service for incoming calls. If not specified this is the name of the device with `- incoming` appended. |
 | outgoingName | The name of the contact sensor service for outgoing calls.  If not specified this is the name of the device with `- outgoing` appended. |
-| incomingLines | The line numbers a device shall react on. Always use array style. Optional |
+| incomingLines | The line numbers a device shall react on. Always use array style or '\*' for no filtering. Optional |
 
 
 ## Accessory Services

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ After [Homebridge](https://github.com/nfarina/homebridge) has been installed:
           "port": "1012",
           "outgoingName": "Ausgehender Anruf",
           "incomingName": "Eingehender Anruf"
+          "incomingLines": ["123456","234567"]
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A device is configured by specifying the following:
 | port | The port where the Fritz device reports call statistic data. This default is 1012. |
 | incomingName | The name of the contact sensor service for incoming calls. If not specified this is the name of the device with `- incoming` appended. |
 | outgoingName | The name of the contact sensor service for outgoing calls.  If not specified this is the name of the device with `- outgoing` appended. |
+| incomingLines | The line numbers a device shall react on. Always use array style. Optional |
 
 
 ## Accessory Services

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -206,14 +206,15 @@ class CallMonitorAccessory {
     // CALL -> CONNECT -> DISCONNECT
     // RING -> CONNECT -> DISCONNECT
     //
-    this.log(data[1] + " on Line " + data[3]);
+    this.log(data[1] + " on Line " + data[4] + " by caller " + data[3]);
     this.log(this._incomingLines);
-    if (this._incomingLines.indexOf(data[3]) >= 0 || this._incomingLines[0] === "*") {
+    if (this._incomingLines.indexOf(data[4]) >= 0 || this._incomingLines[0] === "*") {
       if (data[1] === 'CALL' || data[1] === 'RING') {
         this._activeConnections.push({
           id: data[2],
           line: data[3],
-          direction: data[1],
+          callerId: data[3],
+          direction: data[1]
         });
       }
       else if (data[1] === 'DISCONNECT') {

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -199,7 +199,7 @@ class CallMonitorAccessory {
 
   _onLineReceived(line) {
     const data = line.split(';');
-
+    var activeCall = {};
     //
     // Transitions:
     //
@@ -209,16 +209,18 @@ class CallMonitorAccessory {
     if (data[1] === 'CALL' || data[1] === 'RING') {
       this._activeConnections.push({
         id: data[2],
-        line: data[3],
+        line: data[4],
         callerId: data[3],
         direction: data[1]
       });
+      activeCall = this._activeConnections.filter(item => item.id == data[2])[0];
     }
     else if (data[1] === 'DISCONNECT') {
+      activeCall = this._activeConnections.filter(item => item.id == data[2])[0];
       this._activeConnections = this._activeConnections.filter(item => item.id !== data[2]);
-    }
-    if (this._incomingLines.indexOf(data[4]) >= 0 || this._incomingLines[0] === "*" || data[1] === 'DISCONNECT') {
-      this.log(data[1] + " on Line " + data[4] + " by caller " + data[3] + " with incomingLines config " + this._incomingLines);
+   }
+    if (this._incomingLines.indexOf(activeCall.line) >= 0 || this._incomingLines[0] === "*") {
+      this.log(data[1] + " on line " + activeCall.line + " by caller " + activeCall.callerId + " with incomingLines config: " + this._incomingLines);
       this._reportCallStatus();
     }
   }

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -24,6 +24,7 @@ class CallMonitorAccessory {
 
     this._host = config.address;
     this._port = config.port;
+    this._incomingLines = config.incomingLines;
 
     this._activeConnections = [];
     this._active = false;
@@ -206,14 +207,18 @@ class CallMonitorAccessory {
     // RING -> CONNECT -> DISCONNECT
     //
     if (data[1] === 'CALL' || data[1] === 'RING') {
-      this._activeConnections.push({
-        id: data[2],
-        direction: data[1],
-      });
+      if (this._incomingLines.indexOf(data[3])){
+        this._activeConnections.push({
+          id: data[2],
+          direction: data[1],
+        });  
+      }
     }
     else if (data[1] === 'DISCONNECT') {
-      this._activeConnections = this._activeConnections.filter(item => item.id !== data[2]);
+      if (this._incomingLines.indexOf(data[3])){
+        this._activeConnections = this._activeConnections.filter(item => item.id !== data[2]);
     }
+  }
 
     this._reportCallStatus();
   }

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -206,10 +206,11 @@ class CallMonitorAccessory {
     // CALL -> CONNECT -> DISCONNECT
     // RING -> CONNECT -> DISCONNECT
     //
-    if (this._incomingLines.indexOf(data[3]) || this._incomingLines[0] === "*" || !this._incomingLines) {
+    if (this._incomingLines.indexOf(data[3]) >= 0 || this._incomingLines[0] === "*") {
       if (data[1] === 'CALL' || data[1] === 'RING') {
         this._activeConnections.push({
           id: data[2],
+          line: data[3],
           direction: data[1],
         });
       }

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -206,22 +206,18 @@ class CallMonitorAccessory {
     // CALL -> CONNECT -> DISCONNECT
     // RING -> CONNECT -> DISCONNECT
     //
-    if (data[1] === 'CALL' || data[1] === 'RING') {
-      if (this._incomingLines.indexOf(data[3])){
+    if (this._incomingLines.indexOf(data[3]) || this._incomingLines === ["*"]) {
+      if (data[1] === 'CALL' || data[1] === 'RING') {
         this._activeConnections.push({
           id: data[2],
           direction: data[1],
-        });  
+        });
       }
-    }
-    else if (data[1] === 'DISCONNECT') {
-      if (this._incomingLines.indexOf(data[3])){
+      else if (data[1] === 'DISCONNECT') {
         this._activeConnections = this._activeConnections.filter(item => item.id !== data[2]);
+      }
+      this._reportCallStatus();
     }
-  }
-  if (this._incomingLines.indexOf(data[3])){
-    this._reportCallStatus();
-  }
   }
 }
 

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -206,20 +206,19 @@ class CallMonitorAccessory {
     // CALL -> CONNECT -> DISCONNECT
     // RING -> CONNECT -> DISCONNECT
     //
-    this.log(data[1] + " on Line " + data[4] + " by caller " + data[3]);
-    this.log((this._incomingLines.indexOf(data[4]) >= 0 ? "This call triggers the sensor.":"This call does not trigger the sensor.") + " Config for incomingLines:" + this._incomingLines);
-    if (this._incomingLines.indexOf(data[4]) >= 0 || this._incomingLines[0] === "*") {
-      if (data[1] === 'CALL' || data[1] === 'RING') {
-        this._activeConnections.push({
-          id: data[2],
-          line: data[3],
-          callerId: data[3],
-          direction: data[1]
-        });
-      }
-      else if (data[1] === 'DISCONNECT') {
-        this._activeConnections = this._activeConnections.filter(item => item.id !== data[2]);
-      }
+    if (data[1] === 'CALL' || data[1] === 'RING') {
+      this._activeConnections.push({
+        id: data[2],
+        line: data[3],
+        callerId: data[3],
+        direction: data[1]
+      });
+    }
+    else if (data[1] === 'DISCONNECT') {
+      this._activeConnections = this._activeConnections.filter(item => item.id !== data[2]);
+    }
+    if (this._incomingLines.indexOf(data[4]) >= 0 || this._incomingLines[0] === "*" || this._activeConnections.indexOf(data[2]) >=0) {
+      this.log(data[1] + " on Line " + data[4] + " by caller " + data[3] + " with incomingLines config " + this._incomingLines));
       this._reportCallStatus();
     }
   }

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -206,7 +206,7 @@ class CallMonitorAccessory {
     // CALL -> CONNECT -> DISCONNECT
     // RING -> CONNECT -> DISCONNECT
     //
-    if (this._incomingLines.indexOf(data[3]) || this._incomingLines === ["*"]) {
+    if (this._incomingLines.indexOf(data[3]) || this._incomingLines[0] === "*" || !this._incomingLines) {
       if (data[1] === 'CALL' || data[1] === 'RING') {
         this._activeConnections.push({
           id: data[2],

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -218,7 +218,7 @@ class CallMonitorAccessory {
       this._activeConnections = this._activeConnections.filter(item => item.id !== data[2]);
     }
     if (this._incomingLines.indexOf(data[4]) >= 0 || this._incomingLines[0] === "*" || this._activeConnections.indexOf(data[2]) >=0) {
-      this.log(data[1] + " on Line " + data[4] + " by caller " + data[3] + " with incomingLines config " + this._incomingLines));
+      this.log(data[1] + " on Line " + data[4] + " by caller " + data[3] + " with incomingLines config " + this._incomingLines);
       this._reportCallStatus();
     }
   }

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -217,7 +217,7 @@ class CallMonitorAccessory {
     else if (data[1] === 'DISCONNECT') {
       this._activeConnections = this._activeConnections.filter(item => item.id !== data[2]);
     }
-    if (this._incomingLines.indexOf(data[4]) >= 0 || this._incomingLines[0] === "*" || this._activeConnections.indexOf(data[2]) >=0) {
+    if (this._incomingLines.indexOf(data[4]) >= 0 || this._incomingLines[0] === "*" || data[1] === 'DISCONNECT') {
       this.log(data[1] + " on Line " + data[4] + " by caller " + data[3] + " with incomingLines config " + this._incomingLines);
       this._reportCallStatus();
     }

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -206,6 +206,8 @@ class CallMonitorAccessory {
     // CALL -> CONNECT -> DISCONNECT
     // RING -> CONNECT -> DISCONNECT
     //
+    this.log(data[1] + " on Line " + data[3]);
+    this.log(this._incomingLines);
     if (this._incomingLines.indexOf(data[3]) >= 0 || this._incomingLines[0] === "*") {
       if (data[1] === 'CALL' || data[1] === 'RING') {
         this._activeConnections.push({

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -207,7 +207,7 @@ class CallMonitorAccessory {
     // RING -> CONNECT -> DISCONNECT
     //
     this.log(data[1] + " on Line " + data[4] + " by caller " + data[3]);
-    this.log(this._incomingLines);
+    this.log((this._incomingLines.indexOf(data[4]) >= 0 ? "This call triggers the sensor.":"This call does not trigger the sensor.") + " Config for incomingLines:" + this._incomingLines);
     if (this._incomingLines.indexOf(data[4]) >= 0 || this._incomingLines[0] === "*") {
       if (data[1] === 'CALL' || data[1] === 'RING') {
         this._activeConnections.push({

--- a/src/CallMonitorAccessory.js
+++ b/src/CallMonitorAccessory.js
@@ -219,8 +219,9 @@ class CallMonitorAccessory {
         this._activeConnections = this._activeConnections.filter(item => item.id !== data[2]);
     }
   }
-
+  if (this._incomingLines.indexOf(data[3])){
     this._reportCallStatus();
+  }
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const CallMonitorPlatform = class {
     const { devices } = this.config;
 
     devices.forEach(device => {
-      this.log(`Found device in config: "${devices.name}"`);
+      this.log(`Found device in config: "${device.name}"`);
 
       if (!device.address || !device.name) {
         this.log('Skipping device because it doesn\'t have an address.');
@@ -43,6 +43,7 @@ const CallMonitorPlatform = class {
       device.port = device.port || 1012;
       device.incomingName = device.incomingName || device.name + " - Incoming";
       device.outgoingName = device.outgoingName || device.name + " - Outgoing";
+      device.incomingLines = device.incomingLines || [];
 
       const callMonitor = new CallMonitorAccessory(this.api.hap, this.log, device);
       _accessories.push(callMonitor);

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ const CallMonitorPlatform = class {
       device.port = device.port || 1012;
       device.incomingName = device.incomingName || device.name + " - Incoming";
       device.outgoingName = device.outgoingName || device.name + " - Outgoing";
-      device.incomingLines = device.incomingLines || [];
+      device.incomingLines = device.incomingLines || "*";
 
       const callMonitor = new CallMonitorAccessory(this.api.hap, this.log, device);
       _accessories.push(callMonitor);


### PR DESCRIPTION
With the new config parameter on device level, the selection of single or multiple lines is possible for each device:

`'incomingLines':['123456','234567'];`

If a call comes in for one of these lines, the incoming sensor trigers, otherwise it doesn't. This allows you to create simple automations on specific phone calls.